### PR TITLE
fix page listing

### DIFF
--- a/server/migrations/20220421124045-create-user.js
+++ b/server/migrations/20220421124045-create-user.js
@@ -12,6 +12,7 @@ module.exports = {
         },
         username: {
           type: Sequelize.STRING,
+          primaryKey: true,
         },
         password: {
           type: Sequelize.STRING,

--- a/server/migrations/20220421124245-create-post.js
+++ b/server/migrations/20220421124245-create-post.js
@@ -17,7 +17,7 @@ module.exports = {
           type: Sequelize.TEXT,
         },
         writer: {
-          type: Sequelize.INTEGER,
+          type: Sequelize.STRING,
         },
         createdAt: {
           allowNull: false,

--- a/server/migrations/20220421124432-create-comment.js
+++ b/server/migrations/20220421124432-create-comment.js
@@ -14,7 +14,7 @@ module.exports = {
           type: Sequelize.STRING,
         },
         writer: {
-          type: Sequelize.INTEGER,
+          type: Sequelize.STRING,
         },
         post_id: {
           type: Sequelize.INTEGER,

--- a/server/models/comment.js
+++ b/server/models/comment.js
@@ -10,6 +10,7 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       Comment.belongsTo(models.User, {
         foreignKey: "writer",
+        targetKey: "username",
       });
       Comment.belongsTo(models.Post, {
         foreignKey: "post_id",
@@ -19,7 +20,7 @@ module.exports = (sequelize, DataTypes) => {
   Comment.init(
     {
       content: DataTypes.STRING,
-      writer: DataTypes.INTEGER,
+      writer: DataTypes.STRING,
       post_id: DataTypes.INTEGER,
     },
     {

--- a/server/models/post.js
+++ b/server/models/post.js
@@ -13,6 +13,7 @@ module.exports = (sequelize, DataTypes) => {
       });
       Post.belongsTo(models.User, {
         foreignKey: "writer",
+        targetKey: "username",
       });
     }
   }
@@ -20,7 +21,7 @@ module.exports = (sequelize, DataTypes) => {
     {
       title: DataTypes.STRING,
       content: DataTypes.TEXT,
-      writer: DataTypes.INTEGER,
+      writer: DataTypes.STRING,
     },
     {
       sequelize,

--- a/server/models/user.js
+++ b/server/models/user.js
@@ -10,12 +10,14 @@ module.exports = (sequelize, DataTypes) => {
     static associate(models) {
       User.hasMany(models.Post, {
         foreignKey: "writer",
+        sourceKey: "username",
       });
       User.hasMany(models.Nft, {
         foreignKey: "owner",
       });
       User.hasMany(models.Comment, {
         foreignKey: "writer",
+        sourceKey: "username",
       });
     }
   }

--- a/server/routes/page.js
+++ b/server/routes/page.js
@@ -48,7 +48,7 @@ router.get("/content/:id", async (req, res) => {
   let content = await Post.findOne({
     include: {
       model: Comment,
-      attributes: ["content"],
+      attributes: ["writer", "content", "createdAt", "updatedAt"],
     },
     where: {
       id: req.params.id,


### PR DESCRIPTION
- 글 삭제후 리스트 조회시 뒤에 있는 글이 자리를 빈 자리를 채우도록 변경
- 글 조회시 해당 글에 작성된 댓글의 username, createdAt, updateAt 도 함께 리턴
- content, comment의 writer가 user테이블의 username을 참조하도록 변경

db 구조 수정이 있었기 때문에 마이그레이션을 다시 해야 합니다.

```bash
$ npx sequelize db:migrate:undo:all
$ npx sequelize db:migrate
```

이후 더미데이터 로드와 서버 실행